### PR TITLE
Guidelines for running yarn docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ pm2 logs
 ## Documentation
 
 ```bash
+# Update yarn postdocs script as per your operating system in package.json file,
+Windows:  start docs/index.html
+Linux:    xdg-open docs/index.html
+OSX:      open docs/index.html
+
 # generate and open api documentation
 yarn docs
 ```


### PR DESCRIPTION
We are using the following script for **yarn docs**,
`postdocs": "opn docs/index.html`
But this gives below error on Linux and windows  
`/bin/sh: 1: opn: not found`
We need to update the **Documentation** part with below commands, 
**Windows**:  `start docs/index.html`
**Linux**:    `xdg-open docs/index.html`
**OSX**:      `open docs/index.html`
So that users can update **package.json yarn postdocs** scripts according to the operating system.